### PR TITLE
Feature/toast-notifications Issue:#120

### DIFF
--- a/dhost/frontend/package.json
+++ b/dhost/frontend/package.json
@@ -19,6 +19,7 @@
     "react-redux": "^7.2.4",
     "react-router-dom": "^5.2.0",
     "react-scripts": "^4.0.3",
+    "react-toastify": "^7.0.4",
     "typescript": "^4.1.2",
     "web-vitals": "^2.1.0"
   },

--- a/dhost/frontend/src/App.tsx
+++ b/dhost/frontend/src/App.tsx
@@ -1,3 +1,6 @@
+import { ToastContainer } from 'react-toastify'
+import 'react-toastify/dist/ReactToastify.min.css'
+
 import Footer from "components/Footer"
 import Header from "components/Header"
 import Navbar from "components/Navbar"
@@ -11,6 +14,7 @@ export default function App(): React.ReactElement {
         <Header />
         <Navbar />
         <RouterOutlet />
+        <ToastContainer />
       </div>
       <Footer />
     </div>

--- a/dhost/frontend/src/pages/Home/Home.tsx
+++ b/dhost/frontend/src/pages/Home/Home.tsx
@@ -1,10 +1,12 @@
 import { useTranslation } from "react-i18next"
+import { toast } from "react-toastify"
 
 export default function Home(): React.ReactElement {
   const { t } = useTranslation()
 
   return (
     <div className="container mx-auto">
+      <button onClick={() => toast("test")}>test</button>
       <h2>{t("HOME_TITLE")}</h2>
     </div>
   )

--- a/dhost/frontend/yarn.lock
+++ b/dhost/frontend/yarn.lock
@@ -3522,6 +3522,11 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
+clsx@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -9587,6 +9592,13 @@ react-scripts@^4.0.3:
     workbox-webpack-plugin "5.1.4"
   optionalDependencies:
     fsevents "^2.1.3"
+
+react-toastify@^7.0.4:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-7.0.4.tgz#7d0b743f2b96f65754264ca6eae31911a82378db"
+  integrity sha512-Rol7+Cn39hZp5hQ/k6CbMNE2CKYV9E5OQdC/hBLtIQU2xz7DdAm7xil4NITQTHR6zEbE5RVFbpgSwTD7xRGLeQ==
+  dependencies:
+    clsx "^1.1.1"
 
 react@^17.0.2:
   version "17.0.2"


### PR DESCRIPTION
La lib ([React-Toastify](https://fkhadra.github.io/react-toastify/use-a-controlled-progress-bar)) ajouter nous permet d'afficher des "toasts notifications" de plusieurs types différents (`success`, `alert`, ...) et avec pas mal de flexibilité au niveau du style et UI (on peut prendre le contrôle de la progress-bar pendant les upload/download par exemple) mais **on n’a pas la possibilité de d'avoir des titres pour les toasts**, uniquement du body.

Donc si les titres sont réellement obligatoires il faudra soit trouver une nouvelle librairie qui nous permette d'avoir des titres, soit si aucune librairie nous permet de faire ça ou nous restreint trop en termes de customisation/contrôle, on peut le recoder soit même (ce qui risque d'être plus chronophage et surement moins qualitatif, mais potentiellement plus flexible sur le long terme) donc à peser le pour et le contre.